### PR TITLE
[update] 将 HCLR 全局配置改为单例

### DIFF
--- a/Editor/HybridCLRGlobalSettings.cs
+++ b/Editor/HybridCLRGlobalSettings.cs
@@ -1,10 +1,48 @@
-using System.Collections;
-using System.Collections.Generic;
-using System.Reflection;
+using System.IO;
+using System.Linq;
+using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
+static class HybridCLRGlobalSettingsLoader
+{
+    static string path = "Assets/HybridCLR Data";
+    static string file = $"{path}/HybridCLRGlobalSettings.asset";
+    
+    [MenuItem("Assets/Create/HybridCLR", menuItem = "Assets/Create/HybridCLR/GlobalSettings", priority =90)]
+    static void CreateOrLoadHybridCLRSettings()
+    {
+        var settings = AssetDatabase.LoadAssetAtPath<HybridCLRGlobalSettings>(file);
+        if (!settings)
+        {
+            settings = ScriptableObject.CreateInstance<HybridCLRGlobalSettings>();
+            var fullPath = Path.GetFullPath(path);
+            if (!Directory.Exists(fullPath))
+            {
+                Directory.CreateDirectory(fullPath);
+            }
+            AssetDatabase.CreateAsset(settings, file);
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+        }
+        EditorGUIUtility.PingObject(settings);
+    }
+    class SingletonValidate : AssetPostprocessor
+    {
+        public static void OnPostprocessAllAssets(string[] importedAsset, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
+        {
+            var duplicate = importedAsset.Where(v => v.EndsWith(".asset"))
+                .Select(v => new { key = v, asset = AssetDatabase.LoadAssetAtPath<HybridCLRGlobalSettings>(v) })
+                .Where(v => v.asset && v.key != file)
+                .Select(v => v.key)
+                .ToArray();
+            if (duplicate.Length > 0)
+            {
+                Debug.LogError($"HybridCLRGlobalSettings 配置冗余：\n{string.Join("\n", duplicate)}");
+            }
+        }
+    }
+}
 
-[CreateAssetMenu(fileName = "HybridCLRGlobalSettings", menuName = "HybridCLR/GlobalSettings")]
 public class HybridCLRGlobalSettings : ScriptableObject
 {
     [Header("开启HybridCLR插件")]


### PR DESCRIPTION
1. 首次新增会在 HybridCLR Data 生成全局配置
2. 之后的生成请求只会Ping 这个配置
3. 简单的配置重复导入的报错提醒，告知用户你的配置冗余
