### PR TITLE
[fix] 修复ExistProgram在非Windows平台无法返回正确结果的问题

### DIFF
--- a/Editor/Installer/BashUtil.cs
+++ b/Editor/Installer/BashUtil.cs
@@ -52,7 +52,12 @@ namespace HybridCLR.Editor.Installer
 
         public static bool ExistProgram(string prog)
         {
+#if UNITY_EDITOR_WIN
             return RunCommand(".", "where", new string[] {prog}) == 0;
+#elif UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX
+            return RunCommand(".", "which", new string[] {prog}) == 0;
+#endif
+            return false;
         }
 
 


### PR DESCRIPTION
`linux`和`OSX`中并没有`where`命令