### PR TITLE
shell 空格路径处理

### DIFF
--- a/Data~/iOSBuild/gen_lump.sh
+++ b/Data~/iOSBuild/gen_lump.sh
@@ -36,10 +36,10 @@ function SearchCppFile()
     fi
 }
 
-rm -rf ${GEN_SOURCE_DIR}/lump_cpp
-rm -rf ${GEN_SOURCE_DIR}/lump_mm
-mkdir ${GEN_SOURCE_DIR}/lump_cpp
-mkdir ${GEN_SOURCE_DIR}/lump_mm
+rm -rf "${GEN_SOURCE_DIR}"/lump_cpp
+rm -rf "${GEN_SOURCE_DIR}"/lump_mm
+mkdir "${GEN_SOURCE_DIR}"/lump_cpp
+mkdir "${GEN_SOURCE_DIR}"/lump_mm
 
 OBJECTIVE_FILE_NAME=${GEN_SOURCE_DIR}/lump_mm/lump_libil2cpp_ojective.mm
 echo "#include \"${BASE_DIR}/il2cpp-config.h\"" > ${OBJECTIVE_FILE_NAME}


### PR DESCRIPTION
如果项目名带空格，现在可以正常编译 .a