### PR TITLE
较高版本的Unity GetFunctionPointer不再依赖GUISkin.current,反而高版本unity的GUISkin.c…

### DIFF
--- a/Editor/3rds/UnityHook/MethodHook.cs
+++ b/Editor/3rds/UnityHook/MethodHook.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  Desc: 一个可以运行时 Hook Mono 方法的工具，让你可以无需修改 UnityEditor.dll 等文件就可以重写其函数功能
  Author: Misaka Mikoto
  Github: https://github.com/Misaka-Mikoto-Tech/MonoHook
@@ -85,7 +85,7 @@ namespace MonoHook
 
         private CodePatcher _codePatcher;
 
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_3_OR_NEWER
         /// <summary>
         /// call `MethodInfo.MethodHandle.GetFunctionPointer()` 
         /// will visit static class `UnityEditor.IMGUI.Controls.TreeViewGUI.Styles` and invoke its static constructor,
@@ -97,7 +97,7 @@ namespace MonoHook
 
         static MethodHook()
         {
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_3_OR_NEWER
             s_fi_GUISkin_current = typeof(GUISkin).GetField("current", BindingFlags.Static | BindingFlags.NonPublic);
 #endif
         }
@@ -126,7 +126,7 @@ namespace MonoHook
             if (isHooked)
                 return;
 
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_3_OR_NEWER 
             if (s_fi_GUISkin_current.GetValue(null) != null)
                 DoInstall();
             else
@@ -191,7 +191,7 @@ namespace MonoHook
             if (targetMethod.IsAbstract)
                 throw new Exception($"WRANING: you can not hook abstract method [{methodName}]");
 
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_3_OR_NEWER
             int minMethodBodySize = 10;
 
             {
@@ -358,7 +358,7 @@ namespace MonoHook
             }
         }
 
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_3_OR_NEWER
         private void OnEditorUpdate()
         {
             if (s_fi_GUISkin_current.GetValue(null) != null)
@@ -379,3 +379,4 @@ namespace MonoHook
     }
 
 }
+#endif

--- a/Editor/3rds/UnityHook/MethodHook.cs
+++ b/Editor/3rds/UnityHook/MethodHook.cs
@@ -379,4 +379,3 @@ namespace MonoHook
     }
 
 }
-#endif


### PR DESCRIPTION
…urrent这个值不会立即有值，导致在编辑器compile等时候，hook没有及时注入从而导致打iOS包失败