### PR TITLE
添加复制Dll工具，即可避免繁琐的手动复制操作改名，又可减少手动操作遗漏引起的bug.

### DIFF
--- a/Editor/Settings/HybridCLRSettings.cs
+++ b/Editor/Settings/HybridCLRSettings.cs
@@ -50,5 +50,20 @@ namespace HybridCLR.Editor.Settings
 
         [Header("MethodBridge泛型搜索迭代次数")]
         public int maxMethodBridgeGenericIteration = 10;
+        
+        [Header("AOT dlls 复制目标目录")]
+        public string copyAOTDllsTargetDir = "Assets/StreamingAssets/AOTDlls";
+
+        [Header("复制AOT dlls时对AOTGenericReferences.PatchedAOTAssemblyList的补充")]
+        public string[] copyAOTDllsAddition ={"System"};
+        
+        [Header("热更 dlls 复制目标目录")]
+        public string copyHotUpdateDllsTargetDir = "Assets/StreamingAssets/HotUpdateDlls";
+
+        [Header("复制热更dll时，忽略平台文件夹")]
+        public bool ignorePlatformWhenCopyHotUpdateDll = true;
+        
+        [Header("复制Dlls附加后缀名")] 
+        public string copyDllsExtension = ".bytes";
     }
 }

--- a/Editor/Settings/MenuProvider.cs
+++ b/Editor/Settings/MenuProvider.cs
@@ -1,4 +1,5 @@
 using HybridCLR.Editor.Installer;
+using HybridCLR.Editor.Tool;
 using UnityEditor;
 using UnityEngine;
 
@@ -34,6 +35,11 @@ namespace HybridCLR.Editor.Settings
 
         [MenuItem("HybridCLR/Documents/Bug Report")]
         public static void OpenBugReport() => Application.OpenURL("https://hybridclr.doc.code-philosophy.com/docs/help/issue");
-    }
 
+        [MenuItem("HybridCLR/Tool/CopyDllsWithExtension/AOTDlls")]
+        public static void CopyAOTDlls() => CopyDlls.CopyAOTDlls();
+
+        [MenuItem("HybridCLR/Tool/CopyDllsWithExtension/HotUpdateDlls")]
+        public static void CopyHotUpdateDlls() => CopyDlls.CopyHotUpdateDlls();
+    }
 }

--- a/Editor/Tool.meta
+++ b/Editor/Tool.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6acc8fc82aff23a43a0b4c7ec0c61313
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tool/CopyDlls.cs
+++ b/Editor/Tool/CopyDlls.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using HybridCLR.Editor.Settings;
+using UnityEditor;
+using UnityEngine;
+
+namespace HybridCLR.Editor.Tool
+{
+    public static class CopyDlls
+    {
+        private static readonly Dictionary<string, string> CopyList = new Dictionary<string, string>();
+        private static Assembly _assemblyCsharp;
+        private static string _aotGenericReferenceFileName;
+        private static object _aotGenericReferenceObj;
+
+        /// <summary>
+        /// 复制 AOT Dlls 到指定的文件夹，
+        /// 复制的dll在 AOTGenericReferences.cs 中的 PatchedAOTAssemblyList 和 在设置面板指定的 Addition 共同决定, 二者重复无碍。
+        /// </summary>
+        public static void CopyAOTDlls()
+        {
+            var sourceDir = Path.Combine(SettingsUtil.ProjectDir, SettingsUtil.AssembliesPostIl2CppStripDir, EditorUserBuildSettings.activeBuildTarget.ToString());
+            var targetDir = Path.Combine(SettingsUtil.ProjectDir, HybridCLRSettings.Instance.copyAOTDllsTargetDir, EditorUserBuildSettings.activeBuildTarget.ToString());
+
+            CopyList.Clear();
+
+            if (!Directory.Exists(sourceDir))
+            {
+                Debug.LogWarning("源 AOT Dll 目录不存在，请先执行 Generate/AOTDlls");
+                return;
+            }
+
+            var outputAOTGenericReferenceFile = Path.Combine(Application.dataPath, HybridCLRSettings.Instance.outputAOTGenericReferenceFile);
+            if (File.Exists(outputAOTGenericReferenceFile))
+            {
+                if (string.IsNullOrEmpty(_aotGenericReferenceFileName))
+                {
+                    _aotGenericReferenceFileName = HybridCLRSettings.Instance.outputAOTGenericReferenceFile.Split('/')[^1].Split('.')[0];
+                }
+
+                try
+                {
+                    if (_assemblyCsharp == null) _assemblyCsharp = Assembly.LoadFile(Path.Combine(SettingsUtil.ProjectDir, "Library", "ScriptAssemblies", "Assembly-CSharp.dll"));
+                    foreach (var type in _assemblyCsharp.GetTypes())
+                    {
+                        if (type.Name.Equals(_aotGenericReferenceFileName))
+                        {
+                            var fi = type.GetField("PatchedAOTAssemblyList", BindingFlags.Public | BindingFlags.Static);
+                            if (fi != null)
+                            {
+                                _aotGenericReferenceObj ??= Activator.CreateInstance(type);
+                                if (_aotGenericReferenceObj != null)
+                                {
+                                    var value = fi.GetValue(_aotGenericReferenceObj);
+                                    foreach (var str in (IReadOnlyList<string>)value)
+                                    {
+                                        CopyList[str] = Path.Combine(sourceDir, str);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.Log($"加载 Assembly-CSharp.dll 异常: {e.Message}");
+                    throw;
+                }
+            }
+            else
+            {
+                Debug.LogWarning("未检测到 AOTGenericReferences.cs 文件，仅复制 Addition 部分");
+            }
+
+            if (HybridCLRSettings.Instance.copyAOTDllsAddition != null)
+            {
+                foreach (var addition in HybridCLRSettings.Instance.copyAOTDllsAddition)
+                {
+                    if (string.IsNullOrEmpty(addition)) continue;
+                    CopyList[addition + ".dll"] = Path.Combine(sourceDir, addition + ".dll");
+                }
+            }
+
+            Copy(targetDir, (str) => { Debug.LogWarning($"{str} 不存在，复制时被跳过"); }, (str) => { Debug.Log($"成功复制AOTDll: {str}"); });
+        }
+
+        public static void CopyHotUpdateDlls()
+        {
+            var sourceDir = Path.Combine(SettingsUtil.ProjectDir, SettingsUtil.HotUpdateDllsRootOutputDir, EditorUserBuildSettings.activeBuildTarget.ToString());
+            string targetDir;
+            if (HybridCLRSettings.Instance.ignorePlatformWhenCopyHotUpdateDll)
+            {
+                targetDir = Path.Combine(SettingsUtil.ProjectDir, HybridCLRSettings.Instance.copyHotUpdateDllsTargetDir);
+            }
+            else
+            {
+                targetDir = Path.Combine(SettingsUtil.ProjectDir, HybridCLRSettings.Instance.copyHotUpdateDllsTargetDir, EditorUserBuildSettings.activeBuildTarget.ToString());
+            }
+
+            CopyList.Clear();
+
+            if (!Directory.Exists(sourceDir))
+            {
+                Debug.LogError("源 HotUpdate Dll 目录不存在，请先执行 CompileDll");
+                return;
+            }
+
+            foreach (var definition in HybridCLRSettings.Instance.hotUpdateAssemblyDefinitions)
+            {
+                CopyList[definition.name + ".dll"] = Path.Combine(sourceDir, definition.name + ".dll");
+            }
+
+            foreach (var assembly in HybridCLRSettings.Instance.hotUpdateAssemblies)
+            {
+                if (string.IsNullOrEmpty(assembly)) continue;
+                CopyList[assembly + ".dll"] = Path.Combine(sourceDir, assembly + ".dll");
+            }
+
+            if (CopyList.Count == 0)
+            {
+                Debug.LogWarning("请检测 Setting 面板是否正确指定了热更 dll");
+                return;
+            }
+
+            Copy(targetDir, (str) => { Debug.LogError($"{str} 不存在，请执行 CompileDll 后重试"); }, (str) => { Debug.Log($"成功复制热更Dll: {str}"); });
+        }
+
+        private static void Copy(string targetDir, Action<string> noExistsAction, Action<string> successAction = null)
+        {
+            if (!Directory.Exists(targetDir))
+                Directory.CreateDirectory(targetDir);
+
+            foreach (var copy in CopyList)
+            {
+                if (File.Exists(copy.Value))
+                {
+                    try
+                    {
+                        var destFileName = Path.Combine(targetDir, copy.Key + HybridCLRSettings.Instance.copyDllsExtension);
+                        if (File.Exists(destFileName)) File.Delete(destFileName);
+                        File.Copy(copy.Value, destFileName);
+                        successAction?.Invoke(copy.Key);
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogError($"在复制{copy.Key}文件时发生异常，请重试 \n {e.Message}");
+                        throw;
+                    }
+                }
+                else
+                {
+                    noExistsAction?.Invoke(copy.Key);
+                }
+            }
+
+            AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate);
+        }
+    }
+}

--- a/Editor/Tool/CopyDlls.cs.meta
+++ b/Editor/Tool/CopyDlls.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8fbba1c939b0c1044a02f72c8d421d09
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
操作步骤：

1. 点击 HybridCLR/Setting
2. 在HybirdCLR设置中找到复制Dlls，点击三角展开设置
3. 填入相对于工程目录的复制目标目录
4. 填入自己想要的后缀名
5. 点击 HybridCLR/Tool/CopyDllsWithExtension/ 下的 AOTDlls 或 HotUpdateDlls 来执行复制
6. 检查输出面板是否有异常信息。

说明：
复制 HotUpdate Dll 是由 HybridCLR 设置中的 hotUpdateAssemblyDefinitions 和 hotUpdateAssemblies 共同指定 复制裁剪后的AOT Dll 是由 AOTGenericReferences 脚本中的 PatchedAOTAssemblyList（注：AOTGenericReferences  不存在也没关系） 和 HybridCLR设置中复制 Dlls 的 Copy AOT Dlls Addition 共同指定的，二者重复无碍。