### PR TITLE
修复报错：BuildFailedException: Build path contains a project previously built without the "Create Visual Studio Solution"

### DIFF
--- a/Editor/Commands/StripAOTDllCommand.cs
+++ b/Editor/Commands/StripAOTDllCommand.cs
@@ -84,6 +84,10 @@ namespace HybridCLR.Editor.Commands
             bool oldBuildScriptsOnly = EditorUserBuildSettings.buildScriptsOnly;
             EditorUserBuildSettings.buildScriptsOnly = true;
 
+            string location = GetLocationPathName(outputPath, target);
+            string oldBuildLocation = EditorUserBuildSettings.GetBuildLocation(target);
+            EditorUserBuildSettings.SetBuildLocation(target, location);
+
             switch (target)
             {
                 case BuildTarget.StandaloneWindows:
@@ -113,7 +117,7 @@ namespace HybridCLR.Editor.Commands
             BuildPlayerOptions buildPlayerOptions = new BuildPlayerOptions()
             {
                 scenes = EditorBuildSettings.scenes.Where(s => s.enabled).Select(s => s.path).ToArray(),
-                locationPathName = GetLocationPathName(outputPath, target),
+                locationPathName = location,
                 options = buildOptions,
                 target = target,
                 targetGroup = BuildPipeline.GetBuildTargetGroup(target),
@@ -122,6 +126,8 @@ namespace HybridCLR.Editor.Commands
             var report = BuildPipeline.BuildPlayer(buildPlayerOptions);
 
             EditorUserBuildSettings.buildScriptsOnly = oldBuildScriptsOnly;
+            EditorUserBuildSettings.SetBuildLocation(target, oldBuildLocation);
+
             switch (target)
             {
                 case BuildTarget.StandaloneWindows:


### PR DESCRIPTION
在Build Settings窗口打包时，Unity会记录输出路径（相当于调用了`EditorUserBuildSettings.SetBuildLocation`）。下次使用`BuildPipeline.BuildPlayer`打包时，Unity会用之前记录的路径检查其中打包的结果是否开启了"Create Visual Studio Solution"。正确的逻辑应该是让Unity检查本次打包的输出路径。