### PR TITLE
支持导入为bytes的程序集文件

### DIFF
--- a/Editor/Meta/FixedSetAssemblyResolver.cs
+++ b/Editor/Meta/FixedSetAssemblyResolver.cs
@@ -29,6 +29,12 @@ namespace HybridCLR.Editor.Meta
                     Debug.Log($"[FixedSetAssemblyResolver] resolve:{assemblyName} path:{assemblyPath}");
                     return true;
                 }
+                assemblyPath = $"{_rootDir}/{assemblyName}.bytes";
+                if (File.Exists(assemblyPath))
+                {
+                    Debug.Log($"[FixedSetAssemblyResolver] resolve:{assemblyName} path:{assemblyPath}");
+                    return true;
+                }
             }
             assemblyPath = null;
             return false;


### PR DESCRIPTION
其他项目编译的dll如果直接放入编辑器会触发编译，影响效率，直接导入与加载bytes文件程序集 更方便