### PR TITLE
Force strip AOT assembly resources, reduce the size of metadata.

### DIFF
--- a/Editor/AOT/AOTAssemblyMetadataStripper.cs
+++ b/Editor/AOT/AOTAssemblyMetadataStripper.cs
@@ -13,7 +13,14 @@ namespace HybridCLR.Editor.AOT
     {
         public static byte[] Strip(byte[] assemblyBytes)
         {
-            var mod = ModuleDefMD.Load(assemblyBytes);
+            var context = ModuleDef.CreateModuleContext();
+            var readerOption = new ModuleCreationOptions(context)
+            {
+                Runtime = CLRRuntimeReaderKind.Mono
+            };
+            var mod = ModuleDefMD.Load(assemblyBytes, readerOption);
+            // remove all resources
+            mod.Resources.Clear();
             foreach (var type in mod.GetTypes())
             {
                 if (type.HasGenericParameters)


### PR DESCRIPTION
补充元数据DLL应该不需要 Resources，是否可以强行剥离。
这样对于mscorlib.dll这种内部包含了Resources的DLL文件可以减小300kb左右的尺寸

![20250402182318](https://github.com/user-attachments/assets/b2b4019c-2243-4b33-8ce3-10cc149b0b58)
