### PR TITLE
扩展 GenerateStripedAOTDlls 支持传入 BuildPlayerOptions 中的assetBundleManife…

### DIFF
--- a/Editor/Commands/StripAOTDllCommand.cs
+++ b/Editor/Commands/StripAOTDllCommand.cs
@@ -66,7 +66,7 @@ namespace HybridCLR.Editor.Commands
             }
         }
 
-        public static void GenerateStripedAOTDlls(BuildTarget target)
+        public static void GenerateStripedAOTDlls(BuildTarget target, string assetBundleManifestPath = null)
         {
             string outputPath = $"{SettingsUtil.HybridCLRDataDir}/StrippedAOTDllsTempProj/{target}";
             BashUtil.RemoveDir(outputPath);
@@ -140,6 +140,10 @@ namespace HybridCLR.Editor.Commands
                     subtarget = (int)StandaloneBuildSubtarget.Server,
 #endif
                 };
+                if (!string.IsNullOrEmpty(assetBundleManifestPath))
+                {
+                    buildPlayerOptions.assetBundleManifestPath = assetBundleManifestPath;
+                }
 
                 var report = BuildPipeline.BuildPlayer(buildPlayerOptions);
 


### PR DESCRIPTION
The path to an manifest file describing all of the asset bundles used in the build (optional).
